### PR TITLE
User can get the average calorie count of a food type across all recipes in the database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
 /.nyc_output
 .env
+.nyc_output

--- a/app.spec.js
+++ b/app.spec.js
@@ -48,6 +48,7 @@ describe('Recipes endpoints API', () => {
     test("should return a 200 status code and the average calories", () => {
       return request(app).get("/api/v1/recipes/average_calorie_count?q=chicken")
       .then(response => {
+        expect(response.statusCode).toBe(200);
         const data = response.body.data;
         expect(data).toHaveProperty('foodType');
         expect(data).toHaveProperty('calorieCount');
@@ -55,6 +56,16 @@ describe('Recipes endpoints API', () => {
         expect(data.calorieCount).toBeCloseTo(2762);
       })
 
+    });
+    describe('When there are no recipes of that food type', () => {
+      test('should return a 400 status code and error message', () => {
+        return request(app).get("/api/v1/recipes/average_calorie_count?q=steak")
+        .then(response => {
+          expect(response.status).toBe(400)
+          expect(response.body.error).toBe("There are no steak recipes")
+        })
+
+      })
     })
   });
 });

--- a/app.spec.js
+++ b/app.spec.js
@@ -46,13 +46,13 @@ describe('Recipes endpoints API', () => {
 
   describe("Test average calories across recipes for a given food type", () => {
     test("should return a 200 status code and the average calories", () => {
-      return request(app).get("/api/v1/recipes/ingredient_count")
+      return request(app).get("/api/v1/recipes/average_calorie_count?q=chicken")
       .then(response => {
-        const data = response.body;
+        const data = response.body.data;
         expect(data).toHaveProperty('foodType');
         expect(data).toHaveProperty('calorieCount');
         expect(data.foodType).toBe('chicken');
-        expect(data.calorieCount).toBeCloseTo(1891.46);
+        expect(data.calorieCount).toBeCloseTo(2762);
       })
 
     })

--- a/app.spec.js
+++ b/app.spec.js
@@ -43,4 +43,18 @@ describe('Recipes endpoints API', () => {
       })
     });
   });
+
+  describe("Test average calories across recipes for a given food type", () => {
+    test("should return a 200 status code and the average calories", () => {
+      return request(app).get("/api/v1/recipes/ingredient_count")
+      .then(response => {
+        const data = response.body;
+        expect(data).toHaveProperty('foodType');
+        expect(data).toHaveProperty('calorieCount');
+        expect(data.foodType).toBe('chicken');
+        expect(data.calorieCount).toBeCloseTo(1891.46);
+      })
+
+    })
+  });
 });

--- a/app.spec.js
+++ b/app.spec.js
@@ -2,7 +2,7 @@ var shell = require('shelljs');
 var request = require("supertest");
 var app = require('./app');
 
-describe('api', () => {
+describe('Recipes endpoints API', () => {
   beforeAll(() => {
     shell.exec('npx sequelize db:create')
     shell.exec('npx sequelize db:migrate')

--- a/routes/api/v1/recipes.js
+++ b/routes/api/v1/recipes.js
@@ -30,7 +30,6 @@ router.get("/average_calorie_count?", function(req, res) {
     raw: true
   })
     .then(result => {
-      console.log(result)
       if(result[0].averageCalorieCount) {
         res.status(200).send(JSON.stringify({
             data: {

--- a/routes/api/v1/recipes.js
+++ b/routes/api/v1/recipes.js
@@ -1,6 +1,8 @@
 var express = require("express");
 var router = express.Router();
 var Recipe = require("../../../models").Recipe;
+const Sequelize = require('sequelize');
+
 
 router.get("/ingredient_count", function(req, res) {
   res.setHeader("Content-Type", "application/json");
@@ -17,6 +19,27 @@ router.get("/ingredient_count", function(req, res) {
       res.status(500).send({ error });
     });
 });
+
+router.get("/average_calorie_count?", function(req, res) {
+  res.setHeader("Content-Type", "application/json");
+  Recipe.findAll({
+    where: {
+      foodType: req.query.q
+    },
+    attributes: [[Sequelize.fn('AVG', Sequelize.col('calorieCount')), 'averageCalorieCount']]
+  })
+    .then(result => {
+      res.status(200).send(JSON.stringify({
+          data: {
+            foodType: req.query.q,
+            calorieCount: parseInt(result[0].dataValues.averageCalorieCount)
+          }
+        }))
+    })
+    .catch(error => {
+      res.status(500).send({error});
+    })
+})
 
 function formatFastJsonRecipes(recipes) {
   var formattedRecipes = [];

--- a/routes/api/v1/recipes.js
+++ b/routes/api/v1/recipes.js
@@ -26,15 +26,22 @@ router.get("/average_calorie_count?", function(req, res) {
     where: {
       foodType: req.query.q
     },
-    attributes: [[Sequelize.fn('AVG', Sequelize.col('calorieCount')), 'averageCalorieCount']]
+    attributes: [[Sequelize.fn('AVG', Sequelize.col('calorieCount')), 'averageCalorieCount']],
+    raw: true
   })
     .then(result => {
-      res.status(200).send(JSON.stringify({
-          data: {
-            foodType: req.query.q,
-            calorieCount: parseInt(result[0].dataValues.averageCalorieCount)
-          }
-        }))
+      console.log(result)
+      if(result[0].averageCalorieCount) {
+        res.status(200).send(JSON.stringify({
+            data: {
+              foodType: req.query.q,
+              calorieCount: parseInt(result[0].averageCalorieCount)
+            }
+          }))
+      } else{
+        res.status(400).send(JSON.stringify({error: `No recipes with ${req.query.q} found in database.`}))
+      }
+
     })
     .catch(error => {
       res.status(500).send({error});

--- a/routes/api/v1/recipes.js
+++ b/routes/api/v1/recipes.js
@@ -39,7 +39,7 @@ router.get("/average_calorie_count?", function(req, res) {
             }
           }))
       } else{
-        res.status(400).send(JSON.stringify({error: `No recipes with ${req.query.q} found in database.`}))
+        res.status(400).send(JSON.stringify({error: `There are no ${req.query.q} recipes`}))
       }
 
     })


### PR DESCRIPTION
# User can get the average calorie count of a food type across all recipes in the database # 
Closes #3 

Ex:
### GET 'api/v1/recipes/average_calorie_count?q=chicken' ###

<img width="903" alt="Screen Shot 2019-05-14 at 11 13 46 PM" src="https://user-images.githubusercontent.com/13354855/57750076-f2fb2880-769d-11e9-9643-b92568bd77fd.png">

## When the food type does not exist in the database ## 
The status error is 400, open to changing it though. 

### GET 'api/v1/recipes/average_calorie_count?q=steak' ###

<img width="886" alt="Screen Shot 2019-05-14 at 11 40 27 PM" src="https://user-images.githubusercontent.com/13354855/57751016-ac0f3200-76a1-11e9-958e-d3850536821f.png">


